### PR TITLE
PG-18-Make-Roll-up-Type-not-required-on-parent-level

### DIFF
--- a/pag_customizations/models/project_task.py
+++ b/pag_customizations/models/project_task.py
@@ -10,7 +10,8 @@ class ProjectTask(models.Model):
     task_status = fields.Many2one('progress.task',string='Status',tracking=True) 
     actual_1 = fields.Char(string="Actual 1",tracking=True)
     actual_2 = fields.Char(string="Actual 2",tracking=True)
-    rollup_type = fields.Selection([('1','Avg'),('2','YTD'),('3','Last Actual (Numeric)'),('4','Last Actual (Percentage)')],string="Rollup Type",tracking=True,required=True)
+    #PG-18-Make-Roll-up-Type-not-required-on-parent-level
+    rollup_type = fields.Selection([('1','Avg'),('2','YTD'),('3','Last Actual (Numeric)'),('4','Last Actual (Percentage)')],string="Rollup Type",tracking=True)
     plan_1 = fields.Char(string="Plan 1",tracking=True)
     plan_2 = fields.Char(string="Plan 2",tracking=True)
     status_id = fields.Char(related='task_status.name',string="Status Name")

--- a/pag_customizations/views/project_task_view.xml
+++ b/pag_customizations/views/project_task_view.xml
@@ -39,7 +39,8 @@
                              <field name="actual_1"/>
                              <field name="plan_2"/>
                              <field name="actual_2"/>
-                            <field name="rollup_type"/>
+                             <!--PG-18-Make-Roll-up-Type-not-required-on-parent-level-->
+                            <field name="rollup_type" required="parent_id"/>
                         </group>
                     </page>
                 </xpath>
@@ -63,7 +64,8 @@
                     <field name="actual_1" optional="hide" readonly="1"/>
                     <field name="plan_2"  optional="hide" readonly="1"/>
                     <field name="actual_2" optional="hide" readonly="1"/>
-                    <field name="rollup_type" optional="hide" readonly="1"/>
+                    <!--PG-18-Make-Roll-up-Type-not-required-on-parent-level-->
+                    <field name="rollup_type" optional="hide" required="parent_id" readonly="1"/>
 
                 </xpath>
                 <!--PG-2-Hide-Blocked-By-tab-on-tasks-->
@@ -96,7 +98,8 @@
                     <field name="actual_1" optional="show"/>
                     <field name="plan_2" optional="show"/>
                    <field name="actual_2"  optional="show"/>
-                   <field name="rollup_type"  optional="show"/>
+                   <!--PG-18-Make-Roll-up-Type-not-required-on-parent-level-->
+                   <field name="rollup_type" required="parent_id"  optional="show"/>
                </xpath>
             </field>
          </record>


### PR DESCRIPTION
Added code for  Rollup type field  required on child task only 